### PR TITLE
Add generate API endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ app.use(express.urlencoded({ extended: true }));
 // Routes
 app.use('/api/auth', require('./src/routes/auth'));
 app.use('/api/sermons', require('./src/routes/sermons'));
+app.use('/api/generate', require('./src/routes/generate'));
 
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/src/controllers/generateController.js
+++ b/src/controllers/generateController.js
@@ -1,0 +1,22 @@
+const { OpenAIApi, Configuration } = require('openai');
+
+const openai = new OpenAIApi(
+  new Configuration({ apiKey: process.env.OPENAI_API_KEY })
+);
+
+exports.generateOutline = async (req, res) => {
+  try {
+    const { theme, length } = req.body;
+    if (!theme || !length) {
+      return res.status(400).json({ message: 'theme and length are required' });
+    }
+    const prompt = `Provide a sermon outline about "${theme}" that would last approximately ${length} minutes.`;
+    const completion = await openai.createChatCompletion({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+    });
+    res.json({ outline: completion.data.choices[0].message.content.trim() });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/routes/generate.js
+++ b/src/routes/generate.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const { generateOutline } = require('../controllers/generateController');
+const router = express.Router();
+
+router.post('/', generateOutline);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- expose `/api/generate` endpoint
- implement controller for sermon outline generation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68478ada83f08327855a131380b395e3