### PR TITLE
Add user profile and preferences API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,7 @@ This project provides a Node.js/Express API with MongoDB for the Sermon Companio
 - `PUT /api/sermons/:id` – update sermon
 - `DELETE /api/sermons/:id` – delete sermon
 - `POST /api/sermons/generate` – generate sermon outline via OpenAI
+- `GET /api/user/me` – get current user profile (requires JWT)
+- `PUT /api/user/preferences` – update user preferences (requires JWT)
 
 This repository only includes server code. The frontend should consume these endpoints.

--- a/server.js
+++ b/server.js
@@ -22,6 +22,7 @@ app.use(express.urlencoded({ extended: true }));
 app.use('/api/auth', require('./src/routes/auth'));
 app.use('/api/sermons', require('./src/routes/sermons'));
 app.use('/api/generate', require('./src/routes/generate'));
+app.use('/api/user', require('./src/routes/user'));
 
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,0 +1,18 @@
+const User = require('../models/User');
+
+exports.getCurrentUser = async (req, res) => {
+  res.json(req.user);
+};
+
+exports.updatePreferences = async (req, res) => {
+  try {
+    req.user.preferences = req.body.preferences;
+    await req.user.save();
+    res.json({
+      message: 'Preferences updated',
+      preferences: req.user.preferences,
+    });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { getCurrentUser, updatePreferences } = require('../controllers/userController');
+const auth = require('../middleware/auth');
+const router = express.Router();
+
+router.get('/me', auth, getCurrentUser);
+router.put('/preferences', auth, updatePreferences);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add `/api/user` routes for profile and preferences
- implement corresponding controller to manage user preferences
- wire the user routes into the server
- document the new endpoints in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68478c21d7388327b68dff39fb7f0076