### PR TITLE
Improve server readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 This project provides a Node.js/Express API with MongoDB for the Sermon Companion application. It includes authentication, sermon CRUD operations and an endpoint to generate sermon outlines using the OpenAI API.
 
+Additional middleware validates required environment variables and provides structured error responses for a more production-ready setup. A root `/` endpoint is also available for basic health checks.
+
 ## Requirements
 - Node.js 18+
 - MongoDB connection string
 - OpenAI API key
+- JWT secret for token signing
 
 ## Setup
 1. Install dependencies:
@@ -13,7 +16,7 @@ This project provides a Node.js/Express API with MongoDB for the Sermon Companio
    npm install
    ```
 2. Create a `.env` file based on `.env.example` and populate your environment variables.
-3. Start the server:
+3. Start the server (the process will exit if required environment variables are missing):
    ```bash
    npm start
    ```
@@ -23,6 +26,7 @@ This project provides a Node.js/Express API with MongoDB for the Sermon Companio
 - `npm run dev` – run in development with nodemon
 
 ## API
+- `GET /` – health check endpoint
 - `POST /api/auth/register` – register user
 - `POST /api/auth/login` – login user
 - `GET /api/sermons` – list sermons (requires JWT)

--- a/server.js
+++ b/server.js
@@ -3,9 +3,11 @@ const cors = require('cors');
 const morgan = require('morgan');
 const dotenv = require('dotenv');
 const connectDB = require('./src/config/db');
+const validateEnv = require('./src/config/validateEnv');
 
 // Load environment variables
 dotenv.config();
+validateEnv();
 
 const app = express();
 
@@ -18,11 +20,23 @@ app.use(morgan('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+app.get('/', (req, res) => {
+  res.json({ message: 'API running' });
+});
+
 // Routes
 app.use('/api/auth', require('./src/routes/auth'));
 app.use('/api/sermons', require('./src/routes/sermons'));
 app.use('/api/generate', require('./src/routes/generate'));
 app.use('/api/user', require('./src/routes/user'));
+
+app.use((req, res, next) => {
+  const err = new Error(`Not Found - ${req.originalUrl}`);
+  err.statusCode = 404;
+  next(err);
+});
+
+app.use(require('./src/middleware/errorHandler'));
 
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/src/config/validateEnv.js
+++ b/src/config/validateEnv.js
@@ -1,0 +1,8 @@
+module.exports = () => {
+  const required = ['MONGODB_URI', 'JWT_SECRET', 'OPENAI_API_KEY'];
+  const missing = required.filter((name) => !process.env[name]);
+  if (missing.length) {
+    console.error(`Missing required environment variables: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+};

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,7 @@
+module.exports = (err, req, res, next) => {
+  console.error(err);
+  const status = err.statusCode || err.status || 500;
+  res.status(status).json({
+    message: err.message || 'Server Error'
+  });
+};


### PR DESCRIPTION
## Summary
- validate critical env variables at startup
- add global error handler and 404 middleware
- expose a simple health check route
- document setup and the new endpoint

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68478d147ea88327afb88a5ffe6ec3c0